### PR TITLE
Rename deviceName config key to device_name

### DIFF
--- a/app/src/main/java/de/reckendrees/systems/tui/expert/UIManager.java
+++ b/app/src/main/java/de/reckendrees/systems/tui/expert/UIManager.java
@@ -1209,7 +1209,7 @@ public class UIManager implements OnTouchListener {
             String deviceFormat = XMLPrefsManager.get(Behavior.device_format);
 
             String username = XMLPrefsManager.get(Ui.username);
-            String deviceName = XMLPrefsManager.get(Ui.deviceName);
+            String deviceName = XMLPrefsManager.get(Ui.device_name);
             if (deviceName == null || deviceName.length() == 0) {
                 deviceName = Build.DEVICE;
             }

--- a/app/src/main/java/de/reckendrees/systems/tui/expert/managers/xml/XMLPrefsManager.java
+++ b/app/src/main/java/de/reckendrees/systems/tui/expert/managers/xml/XMLPrefsManager.java
@@ -821,7 +821,7 @@ public class XMLPrefsManager {
 //            new SimpleMutableEntry("inputFieldBottom", Ui.input_bottom),
 //            new SimpleMutableEntry("username", Ui.username),
 //            new SimpleMutableEntry("showSubmit", Ui.show_enter_button),
-//            new SimpleMutableEntry("deviceName", Ui.deviceName),
+//            new SimpleMutableEntry("deviceName", Ui.device_name),
 //            new SimpleMutableEntry("showRam", Ui.show_ram),
 //            new SimpleMutableEntry("showDevice", Ui.show_device_name),
 //            new SimpleMutableEntry("showToolbar", Toolbar.show_toolbar),

--- a/app/src/main/java/de/reckendrees/systems/tui/expert/managers/xml/options/Ui.java
+++ b/app/src/main/java/de/reckendrees/systems/tui/expert/managers/xml/options/Ui.java
@@ -331,7 +331,7 @@ public enum Ui implements XMLPrefsSave {
             return "Your username";
         }
     },
-    deviceName {
+    device_name {
         @Override
         public String defaultValue() {
             return Build.DEVICE;

--- a/app/src/main/java/de/reckendrees/systems/tui/expert/tuils/Tuils.java
+++ b/app/src/main/java/de/reckendrees/systems/tui/expert/tuils/Tuils.java
@@ -1008,7 +1008,7 @@ public class Tuils {
         String format = XMLPrefsManager.get(Behavior.session_info_format);
         if(format.length() == 0) return null;
 
-        String deviceName = XMLPrefsManager.get(Ui.deviceName);
+        String deviceName = XMLPrefsManager.get(Ui.device_name);
         if(deviceName == null || deviceName.length() == 0) {
             deviceName = Build.DEVICE;
         }


### PR DESCRIPTION
To stay coherent with the other configuration keys being snake_case, I renamed `deviceName` to `device_name`. It should break the actual configured value, but setting it again should be fine.